### PR TITLE
Fix fore new about results ellipsis menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Better Google
 
-Install on Greasy Fork: <https://greasyfork.org/en/scripts/395257-better-google>
+This is a fork by Drwonky to ensure the script stays current.
+
+Install on Greasy Fork: <https://greasyfork.org/en/scripts/420865-better-google-drwonky>

--- a/userscript.js
+++ b/userscript.js
@@ -5,7 +5,7 @@
 // @description  Don't be evil::revert google search results to older style
 // @author       aligo, adambh, tejaslodaya, drwonky
 // @license      MIT
-// @supportURL   https://github.com/aligo/better-google
+// @supportURL   https://github.com/drwonky/better-google
 // @match        https://*.google.com/search?*
 // @include      /^https?://(?:www|encrypted|ipv[46])\.google\.[^/]+/(?:$|[#?]|search|webhp)/
 // @grant        none

--- a/userscript.js
+++ b/userscript.js
@@ -2,7 +2,7 @@
 // @name         Better Google
 // @namespace    google
 // @version      0.1.15.0
-// @description  Don't be evil
+// @description  Don't be evil::revert google search results to older style
 // @author       aligo, adambh, tejaslodaya, drwonky
 // @license      MIT
 // @supportURL   https://github.com/aligo/better-google

--- a/userscript.js
+++ b/userscript.js
@@ -1,11 +1,11 @@
 // ==UserScript==
-// @name         Better Google
+// @name         Better Google Drwonky
 // @namespace    google
 // @version      0.1.15.0
 // @description  Don't be evil::revert google search results to older style
 // @author       aligo, adambh, tejaslodaya, drwonky
 // @license      MIT
-// @supportURL   https://github.com/drwonky/better-google
+// @homepageURL   https://github.com/drwonky/better-google
 // @match        https://*.google.com/search?*
 // @include      /^https?://(?:www|encrypted|ipv[46])\.google\.[^/]+/(?:$|[#?]|search|webhp)/
 // @grant        none
@@ -17,6 +17,8 @@
 
     var betterGoogleRow = function(el) {
         var tbwUpd = el.querySelectorAll('.TbwUpd');
+        var aboutResult = el.querySelectorAll('.csDOgf');
+      
         if (tbwUpd.length > 0) {
             var linkEl = el.querySelector('a');
             var addEl = linkEl.nextSibling;
@@ -57,6 +59,7 @@
                 urlEl.style.width = maxWidth.toString() + 'px';
             }
 
+            betterEl.appendChild(aboutResult[0]);
 
             tbwUpd.forEach(function(el) { el.remove() });
             linkEl.querySelector('br:first-child').remove();

--- a/userscript.js
+++ b/userscript.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @name         Better Google
 // @namespace    google
-// @version      0.1.15
+// @version      0.1.15.0
 // @description  Don't be evil
-// @author       aligo, adambh, tejaslodaya
+// @author       aligo, adambh, tejaslodaya, drwonky
 // @license      MIT
 // @supportURL   https://github.com/aligo/better-google
 // @match        https://*.google.com/search?*

--- a/userscript.js
+++ b/userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Better Google Drwonky
 // @namespace    google
-// @version      0.1.15.0
+// @version      0.1.15.1
 // @description  Don't be evil::revert google search results to older style
 // @author       aligo, adambh, tejaslodaya, drwonky
 // @license      MIT


### PR DESCRIPTION
Google has replaced the caret (arrow) menu for cached results with an ellipsis icon.  This change caused the ellipsis to appear hovering over the search result.

This fix re-parents the ellipsis div under the BetterG div so the results render properly.

This pull request also contains the other changes I made for the fork (I assumed that with world events and the country you are in, you would not be able to merge requests soon).

I will continue to make fixes as necessary and submit pull requests, feel free to cherry-pick the changes.