### PR TITLE
Fixes #36 handling of 'about' result element in betterGoogleRow function

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -81,9 +81,9 @@
                 urlEl.style.width = maxWidth.toString() + 'px';
             }
 
-            var aboutResult = el.querySelectorAll('.csDOgf');
-            if (aboutResult.length > 0) {
-                betterEl.appendChild(aboutResult[0]);
+            var aboutResult = el.querySelector('.csDOgf');
+            if (aboutResult && aboutResult.parentElement !== betterAddEl) {
+                betterAddEl.appendChild(aboutResult);
             }
             tbwUpd.forEach(function(el) { el.remove() });
 

--- a/userscript.js
+++ b/userscript.js
@@ -126,9 +126,11 @@
         style.appendChild(document.createTextNode(''));
         document.head.appendChild(style);
         style.sheet.insertRule(`:root { --btrG-link-color: ${link_color}; }`);
-        style.sheet.insertRule('.btrG { word-break: normal; line-height: 18px; }');
-        style.sheet.insertRule('.btrG .btrAdd { display: inline-block; vertical-align: top; line-height: 0; }');
-        style.sheet.insertRule('.btrG .btrLink { display: inline-block; vertical-align: top; line-height: 18px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-decoration: none !important; color: var(--btrG-link-color); }');
+        style.sheet.insertRule('.btrG { display: flex; align-items: center; gap: 6px; word-break: normal; line-height: 18px; }');
+        style.sheet.insertRule('.btrG .btrAdd { display: inline-flex; align-items: center; flex: 0 0 auto; line-height: 18px; }');
+        style.sheet.insertRule('.btrG .btrAdd .csDOgf { display: inline-flex; align-items: center; height: 18px; margin: 0; padding: 0; }');
+        style.sheet.insertRule('.btrG .btrAdd .csDOgf > div, .btrG .btrAdd .csDOgf [role="button"] { display: inline-flex; align-items: center; height: 18px; margin: 0; padding: 0; }');
+        style.sheet.insertRule('.btrG .btrLink { display: block; flex: 0 1 auto; min-width: 0; line-height: 18px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-decoration: none !important; color: var(--btrG-link-color); }');
         style.sheet.insertRule('.btrG .btrLink cite.iUh30 { color: var(--btrG-link-color); font-size: 16px; }');
         // remove extra space used for new multiline link info card
         style.sheet.insertRule('.yuRUbf h3.DKV0Md { margin-top: 0px; }');


### PR DESCRIPTION
The bug was that the script moved Google’s .csDOgf three-dot menu into .btrAdd, then immediately queried .csDOgf again and appended it directly to .btrG. That second appendChild pulled the menu out of the inline container, letting Google’s own styling render it on the next line under the URL.

I changed it so .csDOgf stays inside .btrAdd, only moving it there if it was not already moved. node --check userscript.js passes.

Made with codex